### PR TITLE
Remove deny update from username

### DIFF
--- a/common/profile-model.js
+++ b/common/profile-model.js
@@ -37,6 +37,7 @@ export default ({ Meteor, Mongo, LinkableModel, LinkParent, ServerTime }) => {
             index: 1,
             unique: true,
             optional: true,
+            custom: SimpleSchema.denyUntrusted,
         },
         createdAt: {
             type: Date,

--- a/common/profile-model.js
+++ b/common/profile-model.js
@@ -37,7 +37,6 @@ export default ({ Meteor, Mongo, LinkableModel, LinkParent, ServerTime }) => {
             index: 1,
             unique: true,
             optional: true,
-            denyUpdate: true,
         },
         createdAt: {
             type: Date,


### PR DESCRIPTION
I currently have use case where I'm unable to set username on account creation. As such I prompt users at the earliest opportunity to set it. But in that case I'll get an error as I'm not able to update the profile.
Also I have another use case where I want the username to be changeable from admin in case user sets an offensive username or when customer requests a change.